### PR TITLE
Add flags for tomorrow and price zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ powercost
     00:00 02:00 04:00 06:00 08:00 10:00 12:00 14:00 16:00 18:00 20:00 22:00 
 ```
 
-You can add the argument "tomorrow" and it'll try to give you the prices for tomorrow.
+You can add the flag "-tomorrow" and it'll try to give you the prices for tomorrow.
 
 
 ## Todo

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/perbu/asciigraph"
 	"github.com/perbu/powercost/powercost"
@@ -8,8 +9,7 @@ import (
 	"time"
 )
 
-func plot(when time.Time) error {
-	zone := "NO1"
+func plot(when time.Time, zone string) error {
 	pc, err := powercost.GetPrices(when, zone)
 	if err != nil {
 		return err
@@ -57,12 +57,16 @@ func plot(when time.Time) error {
 }
 
 func realMain() error {
+	tomorrow := flag.Bool("tomorrow", false, "Show price for tomorrow instead of today")
+	zone := flag.String("zone", "NO1", "Which price zone to show")
+	flag.Parse()
+
 	// check if the argument tomorrow was given:
 	when := time.Now()
-	if len(os.Args) > 1 && os.Args[1] == "tomorrow" {
+	if *tomorrow {
 		when = when.Add(24 * time.Hour)
 	}
-	err := plot(when)
+	err := plot(when, *zone)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Move tomorrow argument to a flag, and add flag for specifying price zone. Note that this changes the behavior of the program -- tomorrow must now be specified as

`  pwrcost -tomorrow`

instead of

`  pwrcost tomorrow`

The flags library also adds a help message:

```
pwrcost -h
Usage of ./pwrcost:
  -tomorrow
    	Show price for tomorrow instead of today
  -zone string
    	Which price zone to show (default "NO1")
```