### PR TITLE
Add flag for short time format

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func plot(when time.Time, zone string) error {
+func plot(when time.Time, zone string, shortTime bool) error {
 	pc, err := powercost.GetPrices(when, zone)
 	if err != nil {
 		return err
@@ -38,28 +38,40 @@ func plot(when time.Time, zone string) error {
 		asciigraph.ColorAbove(asciigraph.Red, highPrice),
 		asciigraph.ColorBelow(asciigraph.DarkGreen, lowPrice))
 	fmt.Println(graphs)
-	fmt.Print("       ")
-	for i := 0; i < 24; i++ {
-		if i%2 == 0 {
-			continue
-		}
-		fmt.Printf("%02d:00 ", i)
-	}
-	fmt.Println()
-	fmt.Print("    ")
-	for i := 0; i < 24; i++ {
-		if i%2 == 1 {
-			continue
-		}
-		fmt.Printf("%02d:00 ", i)
-	}
-	fmt.Println()
+	printXaxisLabels(shortTime)
 	return nil
+}
+
+func printXaxisLabels(shortTime bool) {
+	if shortTime {
+		fmt.Print("     ")
+		for i := 0; i <= 24; i++ {
+			fmt.Printf("%02d ", i)
+		}
+	} else {
+		fmt.Print("       ")
+		for i := 0; i < 24; i++ {
+			if i%2 == 0 {
+				continue
+			}
+			fmt.Printf("%02d:00 ", i)
+		}
+		fmt.Println()
+		fmt.Print("    ")
+		for i := 0; i < 24; i++ {
+			if i%2 == 1 {
+				continue
+			}
+			fmt.Printf("%02d:00 ", i)
+		}
+	}
+	fmt.Println()
 }
 
 func realMain() error {
 	tomorrow := flag.Bool("tomorrow", false, "Show price for tomorrow instead of today")
 	zone := flag.String("zone", "NO1", "Which price zone to show")
+	shortTime := flag.Bool("short-time", false, "Use short time format on axis labels")
 	flag.Parse()
 
 	// check if the argument tomorrow was given:
@@ -67,9 +79,10 @@ func realMain() error {
 	if *tomorrow {
 		when = when.Add(24 * time.Hour)
 	}
+
 	// make sure *zone is uppercase:
 	*zone = strings.ToUpper(*zone)
-	err := plot(when, *zone)
+	err := plot(when, *zone, *shortTime)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a new flag to pwrcost to display hours in short time format
```
$ ./pwrcost -h
Usage of ./pwrcost:
  -short-time
    	Use short time format on axis labels
  -tomorrow
    	Show price for tomorrow instead of today
  -zone string
    	Which price zone to show (default "NO1")
```

This produces the following output:
```
$ ./pwrcost -short-time
 0.63 ┤                                                 ╭─────╮
 0.59 ┤                                                ╭╯     ╰╮
 0.54 ┤                                              ╭─╯       ╰╮
 0.50 ┤                        ╭────────╮          ╭─╯          ╰╮ ╭─────────╮
 0.45 ┤                     ╭──╯        ╰──────────╯             ╰─╯         ╰
 0.41 ┤                    ╭╯
 0.36 ┤                   ╭╯
 0.32 ┼─╮                ╭╯
 0.27 ┤ ╰─╮            ╭─╯
 0.23 ┤   ╰─╮       ╭──╯
 0.18 ┤     ╰───────╯
                             Prices for 2022-11-09 in NO1
     00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
```